### PR TITLE
Fix documentation badge in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Documentation Status](https://app.readthedocs.org/projects/idaesplus/badge/?version=latest)](https://idaesplus-docs.readthedocs.io/en/latest/?badge=latest)
+[![Documentation Status](https://app.readthedocs.org/projects/idaesplus/badge/?version=latest)](https://idaesplus.readthedocs.io/en/latest/?badge=latest)
 
 # IDAES+ Documentation
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Documentation Status](https://app.readthedocs.org/projects/idaesplus/badge/?version=latest)](https://idaesplus.readthedocs.io/en/latest/?badge=latest)
+[![Documentation Status](https://app.readthedocs.org/projects/idaesplus/badge/?version=latest)](https://idaesplus.readthedocs.io/latest)
 
 # IDAES+ Documentation
 


### PR DESCRIPTION
When I navigated to the documentation page using the badge in the README I noticed that the cross-project search wasn't working. This PR updates the badge to point to the correct documentation page. 