### PR TITLE
Add a close button to the popup modal for screenshots

### DIFF
--- a/_static/custom.css
+++ b/_static/custom.css
@@ -117,3 +117,18 @@ img.idaesplus-screenshot {
     max-height: 800px;
   }
 }
+
+/* popup dialog, e.g. for UI screenshots */
+#idaesplus-modal-close {
+  font-family: 'Arial';
+  position: fixed;
+  right: 20px;
+  top: 20px;
+  font-size: 16pt;
+  background-color: rgba(41, 128, 185, 1);
+  padding: 5px;
+  margin: 5px;
+  border: 2px solid white;
+  cursor: pointer;
+  color: white;
+}

--- a/ui_products.md
+++ b/ui_products.md
@@ -68,7 +68,16 @@ User interfaces for IDAES+ models.
                       "</div>"
                     );
                     const sectionList = sections.join("\n");
-                    dialog.innerHTML = `<div class="idaesplus-screenshot-details"><h1>${product.name} screenshots</h1>${sectionList}</div>`;
+
+                    // Populate dialog contents
+                    dialog.innerHTML = `
+                    <span id='idaesplus-modal-close'>CLOSE</span>
+                    <div class="idaesplus-screenshot-details"><h1>${product.name} screenshots</h1>${sectionList}</div>`;
+
+                    // Close dialog when close button clicked
+                    document.getElementById("idaesplus-modal-close").
+                      addEventListener("click", (e) => dialog.close());
+
                     dialog.showModal();
                   });
                 });


### PR DESCRIPTION
On some computers the "light click" method (hit Esc or click behind the window) doesn't seem to work.

So, add an explicit close button. It is fixed so it is always visible even if the dialog scrolls.

<img width="2036" height="1036" alt="image" src="https://github.com/user-attachments/assets/86aadbda-9305-41e7-b741-b8d5d9bb49ad" />
