### PR TITLE
Setup URL checker workflow

### DIFF
--- a/.github/workflows/url_check.yml
+++ b/.github/workflows/url_check.yml
@@ -1,0 +1,36 @@
+name: URL Validation
+
+on:
+  push:
+    branches:
+      - setup-urlchecker
+  pull_request:
+    branches:
+      - main
+  schedule:
+    - cron: '0 3 * * 0'
+  workflow_dispatch:
+    inputs:
+      git-ref:
+        description: Git Hash (Optional)
+        required: false
+
+jobs:
+  url_check:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout source
+      uses: actions/checkout@v4
+    - name: URL Checker
+      uses: urlstechie/urlchecker-action@0.0.34
+      with:
+        # A comma-separated list of file types to cover in the URL checks
+        file_types: .md,.rst,.py
+        # Choose whether to include file with no URLs in the prints.
+        print_all: false
+        # More verbose summary at the end of a run
+        verbose: true
+        # How many times to retry a failed request (defaults to 1)
+        retry_count: 3
+        # The timeout seconds to provide to requests, defaults to 5 seconds
+        timeout: 60

--- a/.github/workflows/url_check.yml
+++ b/.github/workflows/url_check.yml
@@ -3,7 +3,7 @@ name: URL Validation
 on:
   push:
     branches:
-      -setup-urlchecker
+      - setup-urlchecker
   pull_request:
     branches:
       - main

--- a/.github/workflows/url_check.yml
+++ b/.github/workflows/url_check.yml
@@ -4,6 +4,11 @@ on:
   pull_request:
     branches:
       - main
+    types:
+      - opened
+      - reopened
+      - synchronize
+      - ready_for_review
   schedule:
     - cron: '0 3 * * 0'
   workflow_dispatch:

--- a/.github/workflows/url_check.yml
+++ b/.github/workflows/url_check.yml
@@ -1,6 +1,9 @@
 name: URL Validation
 
 on:
+  push:
+    branches:
+      -setup-urlchecker
   pull_request:
     branches:
       - main
@@ -27,7 +30,7 @@ jobs:
       uses: urlstechie/urlchecker-action@0.0.34
       with:
         # A comma-separated list of file types to cover in the URL checks
-        file_types: .md,.rst,.py
+        file_types: .md,.rst,.py,.yaml
         # Choose whether to include file with no URLs in the prints.
         print_all: false
         # More verbose summary at the end of a run

--- a/.github/workflows/url_check.yml
+++ b/.github/workflows/url_check.yml
@@ -1,9 +1,6 @@
 name: URL Validation
 
 on:
-  push:
-    branches:
-      - setup-urlchecker
   pull_request:
     branches:
       - main

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 [![Documentation Status](https://app.readthedocs.org/projects/idaesplus/badge/?version=latest)](https://idaesplus.readthedocs.io/latest)
+[![URL Validation](https://github.com/idaesplus/docs/actions/workflows/url_check.yml/badge.svg?branch=main)](https://github.com/idaesplus/docs/actions/workflows/url_check.yml)
 
 # IDAES+ Documentation
 


### PR DESCRIPTION
This adds a URL checker workflow which will check the repo for invalid links. It will run on any new PRs and also weekly on the main branch. It also adds a status badge to the README.

It is currently failing due to lots of broken links (yay, it's doing its job!): https://github.com/blnicho/idaesplus-docs/actions/runs/23313935598/job/67808289723#step:4:281

I would recommend merging this as-is and then we can fix the links in a subsequent PR.